### PR TITLE
Remove dashes from calendar UIDs

### DIFF
--- a/calendar
+++ b/calendar
@@ -102,7 +102,7 @@ class GCal:
                     'end': { 'dateTime': event.get('dtend').dt.strftime('%Y-%m-%dT%H:%M:%S'), 'timeZone': self._tz },
                     'location': event.get('location').title(),
                     'status': event.get('status').lower(),
-                    'id': event.get('uid').lower(),
+                    'id': event.get('uid').replace('-', '').lower(),
                     'recurrence': get_rrules(event)
                 }
             }


### PR DESCRIPTION
The id for events in Google Calendar can only contain lowercase letters
a-v and digits 0-9. The UIDs of iCalendar events may be UUIDs which are
hexadecimal digits with hyphens, so we have to remove the hyphens.